### PR TITLE
Fix the height issue of a configuration page

### DIFF
--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/render/PageRenderer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/render/PageRenderer.java
@@ -89,7 +89,7 @@ public class PageRenderer extends HttpServlet {
           timeZoneService.getUserTimeZoneInfo(jiraServiceContext).toTimeZone();
 
       String location = page.getLocation();
-      boolean chrome = !(location == null || location.equals("none") || location.equals("no-location"));
+      boolean chrome = !("none".equals(location) || "no-location".equals(location));
 
       Map<String, String> productContext = ParameterContextBuilder.buildContext(request, null, null);
 


### PR DESCRIPTION
Fix the height issue of a configuration page. Configuration page cannot specify a location in the descriptor. However, it shouldn't render as a dialog.

/cc @minhhai2209, @liulikun
