### PR TITLE
Generate plugin from local converter source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This project is originally a submission to [Atlassian's Codegeist 2015](http://d
 4. Package with Atlassian SDK: `atlas-clean && atlas-package`.
 5. Convert Atlassian Connect add-on:
 
-`java -cp target\generated_artifact_id-1.0-SNAPSHOT-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter <artifact_id> <artifact_name> <group_id> <company_name> <company_url> <description> <descriptor_url> <path_to_generated_plugin>`
+`java -cp target\generated_artifact_id-generated_artifact_version-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter <group_id> <descriptor_url> <path_to_generated_plugin>`
 
 The generated plugin's source code will be placed at `path_to_generated_plugin`.
 
 Example:
 
-`java -cp target\generated_artifact_id-1.0-SNAPSHOT-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter example-plugin "Example Plugin" com.example "Example, Inc." http://localhost:7777/homepage "This is an example plugin" http://localhost:7777/descriptor D:\tmp\plugin`
+`java -cp target\generated_artifact_id-generated_artifact_version-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter com.example http://localhost:7777/descriptor D:\tmp\plugin`
 
 For a quick test, use [this simple Atlassian Connect add-on](https://github.com/minhhai2209/jira-plugin-converter-demo).
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This project is originally a submission to [Atlassian's Codegeist 2015](http://d
 4. Package with Atlassian SDK: `atlas-clean && atlas-package`.
 5. Convert Atlassian Connect add-on:
 
-`java -cp target\generated_artifact_id-1.0-SNAPSHOT-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter <artifact_id> <group_id> <company_name> <company_url> <description> <descriptor_url> <path_to_generated_plugin>`
+`java -cp target\generated_artifact_id-1.0-SNAPSHOT-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter <artifact_id> <artifact_name> <group_id> <company_name> <company_url> <description> <descriptor_url> <path_to_generated_plugin>`
 
 The generated plugin's source code will be placed at `path_to_generated_plugin`.
 
 Example:
 
-`java -cp target\generated_artifact_id-1.0-SNAPSHOT-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter example-plugin com.example "Example, Inc." http://localhost:7777/homepage "This is an example plugin" http://localhost:7777/descriptor D:\tmp\plugin 6.x`
+`java -cp target\generated_artifact_id-1.0-SNAPSHOT-jar-with-dependencies.jar minhhai2209.jirapluginconverter.converter.Converter example-plugin "Example Plugin" com.example "Example, Inc." http://localhost:7777/homepage "This is an example plugin" http://localhost:7777/descriptor D:\tmp\plugin`
 
 For a quick test, use [this simple Atlassian Connect add-on](https://github.com/minhhai2209/jira-plugin-converter-demo).
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>generated_group_id</groupId>
   <artifactId>generated_artifact_id</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>generated_artifact_version</version>
 
   <organization>
     <name>generated_company_name</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>generated_company_url</url>
   </organization>
 
-  <name>generated_artifact_id</name>
+  <name>generated_artifact_name</name>
   <description>generated_description</description>
   <packaging>atlassian-plugin</packaging>
 

--- a/src/main/java/minhhai2209/jirapluginconverter/converter/Converter.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/converter/Converter.java
@@ -15,6 +15,7 @@ public class Converter {
     try {
       File root = ConverterUtils.getTemplate(templatePath);
       ConverterUtils.replaceTextInFolder(root, "generated_artifact_id", info.getArtifactId());
+      ConverterUtils.replaceTextInFolder(root, "generated_artifact_name", info.getArtifactName());
       ConverterUtils.replaceTextInFolder(root, "generated_group_id", info.getGroupId());
       ConverterUtils.replaceTextInFolder(root, "generated_company_name", info.getCompany());
       ConverterUtils.replaceTextInFolder(root, "generated_company_url", info.getCompanyUrl());
@@ -36,11 +37,12 @@ public class Converter {
 
     PluginProperties info = new PluginProperties();
     info.setArtifactId(args[0]);
-    info.setGroupId(args[1]);
-    info.setCompany(args[2]);
-    info.setCompanyUrl(args[3]);
-    info.setDescription(args[4]);
-    info.setUrl(args[5]);
-    generate(args[6], info);
+    info.setArtifactName(args[1]);
+    info.setGroupId(args[2]);
+    info.setCompany(args[3]);
+    info.setCompanyUrl(args[4]);
+    info.setDescription(args[5]);
+    info.setUrl(args[6]);
+    generate(args[7], info);
   }
 }

--- a/src/main/java/minhhai2209/jirapluginconverter/converter/Converter.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/converter/Converter.java
@@ -13,16 +13,17 @@ public class Converter {
   public static void generate(String templatePath, PluginProperties info) {
 
     try {
-      File root = ConverterUtils.getTemplate(templatePath);
-      ConverterUtils.replaceTextInFolder(root, "generated_artifact_id", info.getArtifactId());
-      ConverterUtils.replaceTextInFolder(root, "generated_artifact_name", info.getArtifactName());
-      ConverterUtils.replaceTextInFolder(root, "generated_group_id", info.getGroupId());
-      ConverterUtils.replaceTextInFolder(root, "generated_company_name", info.getCompany());
-      ConverterUtils.replaceTextInFolder(root, "generated_company_url", info.getCompanyUrl());
-      ConverterUtils.replaceTextInFolder(root, "generated_description", info.getDescription());
-
       String connectFile = ConverterUtils.getConnectFile(info.getUrl());
       Descriptor descriptor = DescriptorConverter.analyze(connectFile);
+
+      File root = ConverterUtils.getTemplate(templatePath);
+      ConverterUtils.replaceTextInFolder(root, "generated_artifact_id", descriptor.getKey());
+      ConverterUtils.replaceTextInFolder(root, "generated_artifact_version", descriptor.getVersion());
+      ConverterUtils.replaceTextInFolder(root, "generated_artifact_name", descriptor.getName());
+      ConverterUtils.replaceTextInFolder(root, "generated_group_id", info.getGroupId());
+      ConverterUtils.replaceTextInFolder(root, "generated_company_name", descriptor.getVendor().get("name"));
+      ConverterUtils.replaceTextInFolder(root, "generated_company_url", descriptor.getVendor().get("url"));
+      ConverterUtils.replaceTextInFolder(root, "generated_description", descriptor.getDescription());
       ConverterUtils.replaceTextInDescriptor(root, descriptor.getModules());
       ConverterUtils.replaceTextInConfigure(root, descriptor);
       ConverterUtils.replaceNameSpace(root, info.getGroupId());
@@ -36,13 +37,8 @@ public class Converter {
   public static void main(String[] args) {
 
     PluginProperties info = new PluginProperties();
-    info.setArtifactId(args[0]);
-    info.setArtifactName(args[1]);
-    info.setGroupId(args[2]);
-    info.setCompany(args[3]);
-    info.setCompanyUrl(args[4]);
-    info.setDescription(args[5]);
-    info.setUrl(args[6]);
-    generate(args[7], info);
+    info.setGroupId(args[0]);
+    info.setUrl(args[1]);
+    generate(args[2], info);
   }
 }

--- a/src/main/java/minhhai2209/jirapluginconverter/converter/Converter.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/converter/Converter.java
@@ -10,10 +10,10 @@ import java.io.File;
 
 public class Converter {
 
-  public static void generate(String templatePath, PluginProperties info, String version) {
+  public static void generate(String templatePath, PluginProperties info) {
 
     try {
-      File root = ConverterUtils.getTemplate(templatePath, version);
+      File root = ConverterUtils.getTemplate(templatePath);
       ConverterUtils.replaceTextInFolder(root, "generated_artifact_id", info.getArtifactId());
       ConverterUtils.replaceTextInFolder(root, "generated_group_id", info.getGroupId());
       ConverterUtils.replaceTextInFolder(root, "generated_company_name", info.getCompany());
@@ -24,6 +24,7 @@ public class Converter {
       Descriptor descriptor = DescriptorConverter.analyze(connectFile);
       ConverterUtils.replaceTextInDescriptor(root, descriptor.getModules());
       ConverterUtils.replaceTextInConfigure(root, descriptor);
+      ConverterUtils.replaceNameSpace(root, info.getGroupId());
 
       ConverterUtils.copy(root, connectFile);
     } catch (Exception e) {
@@ -40,6 +41,6 @@ public class Converter {
     info.setCompanyUrl(args[3]);
     info.setDescription(args[4]);
     info.setUrl(args[5]);
-    generate(args[6], info, args[7]);
+    generate(args[6], info);
   }
 }

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/descriptor/DefaultWebPanelResource.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/descriptor/DefaultWebPanelResource.java
@@ -6,6 +6,6 @@ public class DefaultWebPanelResource extends Resource {
   public DefaultWebPanelResource(String location) {
     this.location = location;
     this.name = "view";
-    this.type = "${project.groupId}.${project.artifactId}-iframe";
+    this.type = "${project.artifactId}-iframe";
   }
 }

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtHelper.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtHelper.java
@@ -10,16 +10,6 @@ import org.apache.http.NameValuePair;
 
 public class JwtHelper {
 
-  public static String getRelativePath(String url, String baseUrl) {
-    String path = url.split("\\?")[0];
-    int baseUrlLength = baseUrl.length();
-    String relativePath = path.substring(baseUrlLength);
-    if (relativePath.isEmpty()) {
-      relativePath = "/";
-    }
-    return relativePath;
-  }
-
   public static Map<String, String[]> getParameterMap(Map<String, List<String>> parameters) {
     final Map<String, String[]> parameterMap = new HashMap<String, String[]>();
     for (Entry<String, List<String>> parameter : parameters.entrySet()) {

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtVerifier.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtVerifier.java
@@ -1,15 +1,5 @@
 package minhhai2209.jirapluginconverter.plugin.jwt;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
-
 import com.atlassian.jwt.CanonicalHttpRequest;
 import com.atlassian.jwt.core.reader.JwtClaimVerifiersBuilder;
 import com.atlassian.jwt.core.reader.JwtIssuerSharedSecretService;
@@ -21,9 +11,11 @@ import com.atlassian.jwt.reader.JwtClaimVerifier;
 import com.atlassian.jwt.reader.JwtReader;
 import com.atlassian.jwt.reader.JwtReaderFactory;
 
-public class JwtVerifier {
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
 
-  private static final int JWT_REALM_LENGTH = "JWT ".length();
+public class JwtVerifier {
 
   public static boolean verify(
     String relativeURI, String jwtString, Map<String, String[]> parameterMap, final String issuer, final String sharedSecret, String method) {
@@ -45,20 +37,6 @@ public class JwtVerifier {
       return false;
     }
     return true;
-  }
-
-  private static String getJwtToken(String authorization, Map<String, List<String>> parameters) {
-    String jwtToken;
-    List<String> jwtTokenParameter = parameters.get("jwt");
-    if (jwtTokenParameter == null) {
-      if (authorization == null) {
-        return null;
-      }
-      jwtToken = authorization.substring(JWT_REALM_LENGTH);
-    } else {
-      jwtToken = jwtTokenParameter.get(0);
-    }
-    return jwtToken;
   }
 
   private static Map<String, ? extends JwtClaimVerifier> getJwtClaimVerifiers(
@@ -83,12 +61,6 @@ public class JwtVerifier {
     };
     Map<String, ? extends JwtClaimVerifier> jwtClaimVerifier = JwtClaimVerifiersBuilder.build(canonicalHttpRequest);
     return jwtClaimVerifier;
-  }
-
-  private static Map<String, List<String>> getUrlParameters(String url) throws URISyntaxException {
-    List<NameValuePair> pairs = URLEncodedUtils.parse(new URI(url), "UTF-8");
-    Map<String, List<String>> parameters = JwtHelper.getParameters(pairs);
-    return parameters;
   }
 
   private static JwtIssuerSharedSecretService getJwtIssuerSharedSecretService(final String sharedSecret) {

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtVerifier.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtVerifier.java
@@ -11,27 +11,22 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 import com.atlassian.jwt.CanonicalHttpRequest;
-import com.atlassian.jwt.Jwt;
 import com.atlassian.jwt.core.reader.JwtClaimVerifiersBuilder;
 import com.atlassian.jwt.core.reader.JwtIssuerSharedSecretService;
 import com.atlassian.jwt.core.reader.JwtIssuerValidator;
 import com.atlassian.jwt.core.reader.NimbusJwtReaderFactory;
 import com.atlassian.jwt.exception.JwtIssuerLacksSharedSecretException;
 import com.atlassian.jwt.exception.JwtUnknownIssuerException;
-import com.atlassian.jwt.exception.JwtVerificationException;
 import com.atlassian.jwt.reader.JwtClaimVerifier;
 import com.atlassian.jwt.reader.JwtReader;
 import com.atlassian.jwt.reader.JwtReaderFactory;
-
-import minhhai2209.jirapluginconverter.utils.ExceptionUtils;
-import minhhai2209.jirapluginconverter.utils.JsonUtils;
 
 public class JwtVerifier {
 
   private static final int JWT_REALM_LENGTH = "JWT ".length();
 
-  public static JwtClaim read(
-      String url, String authorization, String baseUrl, final String issuer, final String sharedSecret, String method) {
+  public static boolean verify(
+    String relativeURI, String jwtString, Map<String, String[]> parameterMap, final String issuer, final String sharedSecret, String method) {
 
     try {
 
@@ -41,33 +36,15 @@ public class JwtVerifier {
 
       JwtReaderFactory jwtReaderFactory = new NimbusJwtReaderFactory(jwtIssuerValidator, jwtIssuerSharedSecretService);
 
-      final String relativePath = JwtHelper.getRelativePath(url, baseUrl);
-
-      Map<String, List<String>> parameters = getUrlParameters(url);
-
-      final Map<String, String[]> parameterMap = JwtHelper.getParameterMap(parameters);
-
-      Map<String, ? extends JwtClaimVerifier> jwtClaimVerifier = getJwtClaimVerifiers(relativePath, parameterMap, method);
-
-      String jwtString = getJwtToken(authorization, parameters);
-      if (jwtString == null) {
-        return null;
-      }
+      Map<String, ? extends JwtClaimVerifier> jwtClaimVerifier = getJwtClaimVerifiers(relativeURI, parameterMap, method);
 
       JwtReader jwtReader = jwtReaderFactory.getReader(jwtString);
-      Jwt jwt = jwtReader.readAndVerify(jwtString, jwtClaimVerifier);
-
-      String claimJson = jwt.getJsonPayload();
-      JwtClaim claim = JsonUtils.fromJson(claimJson, JwtClaim.class);
-
-      return claim;
-
-    } catch (JwtVerificationException e) {
-      return null;
+      jwtReader.readAndVerify(jwtString, jwtClaimVerifier);
     } catch (Exception e) {
-      ExceptionUtils.throwUnchecked(e);
+      System.out.println("JWT VERIFY ERROR: " + e.getMessage());
+      return false;
     }
-    return null;
+    return true;
   }
 
   private static String getJwtToken(String authorization, Map<String, List<String>> parameters) {

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/properties/PluginProperties.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/properties/PluginProperties.java
@@ -6,6 +6,7 @@ public class PluginProperties {
   private String companyUrl;
   private String groupId;
   private String artifactId;
+  private String artifactName;
   private String url;
   private String description;
 
@@ -57,4 +58,11 @@ public class PluginProperties {
     this.description = description;
   }
 
+  public String getArtifactName() {
+    return artifactName;
+  }
+
+  public void setArtifactName(String artifactName) {
+    this.artifactName = artifactName;
+  }
 }

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/rest/RestAuthenticationFilter.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/rest/RestAuthenticationFilter.java
@@ -8,18 +8,21 @@ import com.atlassian.seraph.auth.DefaultAuthenticator;
 import com.google.common.collect.Iterables;
 import minhhai2209.jirapluginconverter.plugin.jwt.JwtClaim;
 import minhhai2209.jirapluginconverter.plugin.jwt.JwtVerifier;
-import minhhai2209.jirapluginconverter.plugin.setting.JiraUtils;
 import minhhai2209.jirapluginconverter.plugin.setting.KeyUtils;
 import minhhai2209.jirapluginconverter.plugin.setting.PluginSetting;
+import minhhai2209.jirapluginconverter.utils.JsonUtils;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Collection;
+import java.util.Map;
 
 public class RestAuthenticationFilter implements Filter {
+  private static final int JWT_REALM_LENGTH = "JWT ".length();
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
@@ -33,37 +36,41 @@ public class RestAuthenticationFilter implements Filter {
 
     HttpServletRequest request = (HttpServletRequest) servletRequest;
     String authorization = request.getHeader("Authorization");
-    if (authorization != null) {
-      if (authorization.startsWith("JWT")) {
-        // only process if Authorization header is JWT token
-        String url = request.getRequestURL().toString();
-        String queryString = request.getQueryString();
-        if (queryString != null) {
-          url += queryString;
-        }
-        String method = request.getMethod();
-        JwtClaim claim = JwtVerifier.read(
-            url,
-            authorization,
-            JiraUtils.getBaseUrl(),
-            PluginSetting.getDescriptor().getKey(),
+    if (authorization != null && authorization.startsWith("JWT ")) {
+      // only process if Authorization header is JWT token
+      String jwtString = authorization.substring(JWT_REALM_LENGTH);
+      String[] jwtSegements = jwtString.split("\\.");
+      if (jwtSegements.length == 3) {
+        String claimSegmentJson = new String(Base64.getDecoder().decode(jwtSegements[1]));
+        JwtClaim unverifiedClaim = JsonUtils.fromJson(claimSegmentJson, JwtClaim.class);
+        String descriptorKey = PluginSetting.getDescriptor().getKey();
+        if (descriptorKey.equals(unverifiedClaim.getIss())) {
+          // only process requests for this plugin
+          String relativeURI = request.getRequestURI().substring(request.getContextPath().length());
+          Map<String, String[]> parameterMap = request.getParameterMap();
+          String method = request.getMethod();
+          boolean verified = JwtVerifier.verify(
+            relativeURI,
+            jwtString,
+            parameterMap,
+            descriptorKey,
             KeyUtils.getSharedSecret(),
             method);
-        if (claim == null) {
-          // only in this case does this filter block the request
-          authorized = false;
-          HttpServletResponse response = (HttpServletResponse) servletResponse;
-          response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-        } else {
-
-          UserUtil userUtil = ComponentAccessor.getUserUtil();
-          Collection<User> admins = userUtil.getJiraAdministrators();
-          User admin = Iterables.get(admins, 0);
-          String adminName = admin.getName();
-          ApplicationUser applicationAdmin = userUtil.getUserByName(adminName);
-          HttpSession httpSession = request.getSession();
-          httpSession.setAttribute(DefaultAuthenticator.LOGGED_IN_KEY, applicationAdmin);
-          httpSession.setAttribute(DefaultAuthenticator.LOGGED_OUT_KEY, null);
+          if (verified) {
+            UserUtil userUtil = ComponentAccessor.getUserUtil();
+            Collection<User> admins = userUtil.getJiraAdministrators();
+            User admin = Iterables.get(admins, 0);
+            String adminName = admin.getName();
+            ApplicationUser applicationAdmin = userUtil.getUserByName(adminName);
+            HttpSession httpSession = request.getSession();
+            httpSession.setAttribute(DefaultAuthenticator.LOGGED_IN_KEY, applicationAdmin);
+            httpSession.setAttribute(DefaultAuthenticator.LOGGED_OUT_KEY, null);
+          } else {
+            // only in this case does this filter block the request
+            authorized = false;
+            HttpServletResponse response = (HttpServletResponse) servletResponse;
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+          }
         }
       }
     }
@@ -71,7 +78,6 @@ public class RestAuthenticationFilter implements Filter {
       chain.doFilter(servletRequest, servletResponse);
     }
   }
-
   @Override
   public void destroy() {
   }

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/rest/RestAuthenticationFilter.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/rest/RestAuthenticationFilter.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 
 public class RestAuthenticationFilter implements Filter {
-  private static final int JWT_REALM_LENGTH = "JWT ".length();
+  private static final String JWT_REALM = "JWT ";
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
@@ -36,9 +36,9 @@ public class RestAuthenticationFilter implements Filter {
 
     HttpServletRequest request = (HttpServletRequest) servletRequest;
     String authorization = request.getHeader("Authorization");
-    if (authorization != null && authorization.startsWith("JWT ")) {
+    if (authorization != null && authorization.startsWith(JWT_REALM)) {
       // only process if Authorization header is JWT token
-      String jwtString = authorization.substring(JWT_REALM_LENGTH);
+      String jwtString = authorization.substring(JWT_REALM.length());
       String[] jwtSegements = jwtString.split("\\.");
       if (jwtSegements.length == 3) {
         String claimSegmentJson = new String(Base64.getDecoder().decode(jwtSegements[1]));

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/setting/PluginSetting.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/setting/PluginSetting.java
@@ -18,7 +18,7 @@ public class PluginSetting {
 
   public static final String ARTIFACT_ID = "generated_artifact_id";
 
-  public static final String PLUGIN_KEY = GROUP_ID + "." + ARTIFACT_ID;
+  public static final String PLUGIN_KEY = ARTIFACT_ID;
 
   public static final String URL_SAFE_PLUGIN_KEY = GROUP_ID + "-" + ARTIFACT_ID;
 

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -1,4 +1,4 @@
-<atlassian-plugin key="${project.groupId}.${project.artifactId}" name="${project.name}"
+<atlassian-plugin key="${project.artifactId}" name="${project.name}"
   plugins-version="2">
   
   <!-- plugin info -->
@@ -31,15 +31,15 @@
     <context>atl.admin</context>
     <context>atl.general</context>
 
-    <dependency>${project.groupId}.${project.artifactId}:dialog-page-resource</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:remote-condition</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:iframe-host-css</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:iframe-host-js</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:ap-extensions</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:ap-user</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:workflow-post-function</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:events</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:create-issue-dialog</dependency>
+    <dependency>${project.artifactId}:dialog-page-resource</dependency>
+    <dependency>${project.artifactId}:remote-condition</dependency>
+    <dependency>${project.artifactId}:iframe-host-css</dependency>
+    <dependency>${project.artifactId}:iframe-host-js</dependency>
+    <dependency>${project.artifactId}:ap-extensions</dependency>
+    <dependency>${project.artifactId}:ap-user</dependency>
+    <dependency>${project.artifactId}:workflow-post-function</dependency>
+    <dependency>${project.artifactId}:events</dependency>
+    <dependency>${project.artifactId}:create-issue-dialog</dependency>
   </web-resource>
 
   <web-resource key="dialog-page-resource">
@@ -49,8 +49,8 @@
   <web-resource key="atlassian-connect-dashboard-item-resources" name="Connect resources for dashboard page.">
     <context>atl.dashboard</context>
 
-    <dependency>${project.groupId}.${project.artifactId}:atlassian-connect-resources</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:dashboard-item</dependency>
+    <dependency>${project.artifactId}:atlassian-connect-resources</dependency>
+    <dependency>${project.artifactId}:dashboard-item</dependency>
   </web-resource>
 
   <!-- JavaScript API Core -->
@@ -68,17 +68,17 @@
     <resource type="download" name="connect-history.js" location="/js/core/connect-host-history.js" />
     <resource type="download" name="connect-dialog.js" location="/js/core/connect-host-dialog.js" />
     <resource type="download" name="connect-inline-dialog.js" location="/js/core/connect-host-inline-dialog.js" />
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:iframe-host-js</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:iframe-host-js</dependency>
   </web-resource>
 
   <web-resource key="ap-user">
     <resource type="download" name="user.js" location="/js/iframe/host/user.js" />
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
   </web-resource>
 
   <web-resource key="iframe-host-js">
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
     <resource type="download" name="main.js" location="/js/iframe/host/main.js" />
     <resource type="download" name="content-resolver.js" location="/js/iframe/host/content-resolver.js" />
     <dependency>com.atlassian.auiplugin:dialog2</dependency>
@@ -86,7 +86,7 @@
 
   <web-resource key="remote-condition">
     <resource type="download" name="remote.js" location="js/condition/remote.js" />
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
   </web-resource>
 
   <!-- JIRA specific javascript modules -->
@@ -95,28 +95,28 @@
     <resource type="download" name="workflow-post-function.js" location="js/jira/workflow-post-function/workflow-post-function.js" />
     <resource type="download" name="workflow-post-function-rpc.js" location="js/jira/workflow-post-function/workflow-post-function-rpc.js" />
     <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
   </web-resource>
 
   <web-resource key="dashboard-item">
     <resource type="download" name="dashboard-item.js" location="js/jira/dashboard-item/dashboard-item.js" />
 
     <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
   </web-resource>
 
   <web-resource key="create-issue-dialog">
     <resource type="download" name="create-issue-dialog.js" location="/js/jira/issue/issue.js" />
     <resource type="download" name="create-issue-dialog-rpc.js" location="/js/jira/issue/issue-rpc.js" />
     <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
   </web-resource>
 
   <web-resource key="events">
     <resource type="download" name="jira-events.js" location="/js/jira/events/events.js" />
     <resource type="download" name="jira-events-rpc.js" location="/js/jira/events/events-rpc.js" />
     <dependency>com.atlassian.auiplugin:ajs</dependency>
-    <dependency>${project.groupId}.${project.artifactId}:ap-core</dependency>
+    <dependency>${project.artifactId}:ap-core</dependency>
   </web-resource>
   
   <!-- jira information -->


### PR DESCRIPTION
1. generate plugin from local converter source instead of github
2. replace Java Namespace in generated code with group id
3. pass in artifact name from the command line
4. use `${project.artifactId}` to refer to the resource instead of `${project.groupId}.${project.artifactId}`  as  `${project.artifactId}` is unique on Atlassian Marketplace, and if the plugin is sharing with a Cloud listing,  that's the ID we have to use.
5. No need to pass in version from command line as it's generating from local source.
6. Fix JWT authentication.
7. Get plugin info from the descriptor as much as possible instead of command line args.
